### PR TITLE
Automating the assignment of the floating IP to the instance

### DIFF
--- a/demo/access.md
+++ b/demo/access.md
@@ -63,7 +63,7 @@ openstack server create \
     --flavor tiny --key-name default --network private --security-group basic \
     --image cirros test-server
 openstack floating ip create public
-openstack server add floating ip test-server <FLOATING_IP>
+openstack server add floating ip test-server $(openstack floating ip list -c "Floating IP Address" -f value)
 ```
 4. From the bastion access to the VM:
 


### PR DESCRIPTION
Automating the assignment of the floating IP to the instance instead of letting the user specifying it manually, which is prone to error.